### PR TITLE
Editable bugfix

### DIFF
--- a/src/db/MongoDB.js
+++ b/src/db/MongoDB.js
@@ -110,7 +110,7 @@ class MongoDB {
 
     async newLine (documentLink, previousUuid, uuid, content) {
         // Insert a line at the right place
-        //TODO is it possible in one operation ? 
+        //TODO is it possible in one operation ?
         // TODO is it possible to implement with bulk?
         try {
             let doc = await this.documentsCollection.findOne({documentLink: documentLink});
@@ -206,17 +206,18 @@ class MongoDB {
             for (let request of requests) {
                 let requestType = request.type;
                 let data = request.data;
+                let results = ""
                 switch (requestType) {
                     case 'set-line':
-                        let results = await this.setLine(documentLink, data.id, data.content);
+                        results = await this.setLine(documentLink, data.id, data.content);
                         if (!results) success = false;
                         break;
                     case 'new-line':
-                        let results = await this.newLine(documentLink, data.previous, data.id, data.content);
+                        results = await this.newLine(documentLink, data.previous, data.id, data.content);
                         if (!results) success = false;
                         break;
                     case 'delete-line':
-                        let results = await this.deleteLine(documentLink, data.id);
+                        results = await this.deleteLine(documentLink, data.id);
                         if (!results) success = false;
                         break;
                 }

--- a/src/publics/js/dev/page/editor/editable.js
+++ b/src/publics/js/dev/page/editor/editable.js
@@ -137,16 +137,18 @@ export default class Editable{
 
             const line = getNodeFromAttribute('uuid');
 
-            if(!line) return;
+            if(!line){
+                e.preventDefault();
+                temporaryCardAlert('Editor', 'Sorry, your action has been canceled because you are not on any line.', 5000);
+                return;
+            }
 
             if(!anchorParent.hasAttribute('uuid')
                 || !focusParent.hasAttribute('uuid')
                 || ((Caret.getBeginPosition(line) === 0
                     || Caret.getEndPosition(line) === 0)
                     ) && anchorParent !== focusParent){
-                e.preventDefault();
-                temporaryCardAlert('Override', 'Sorry, you can\'t override the first char of a line', 5000);
-                return;
+                Caret.setRangeStart(line, 1);
             }
 
             switch (e.keyCode) {
@@ -155,6 +157,11 @@ export default class Editable{
                     this.insertTab();
                     break;
                 case 13: // enter
+                    if(e.shiftKey){
+                        temporaryCardAlert('Shift+Enter', 'Please just use Enter to avoid any bugs.', 5000);
+                        e.preventDefault();
+                        return;
+                    }
                     if(this.keepSpace){
                         Debug.debug('Prevent action when trying to add new line (key is probably maintain).');
                         e.preventDefault();

--- a/src/publics/js/dev/utils/caret.js
+++ b/src/publics/js/dev/utils/caret.js
@@ -67,6 +67,22 @@ export default class Caret{
         }
     }
 
+
+    /**
+     * Set the start range of the user caret on specified position in element or children
+     * @param {HTMLElement|Node} element
+     * @param {number} position
+     */
+    static setRangeStart(element, position) {
+        if (position >= 0) {
+            let selection = document.getSelection();
+
+            let range = Caret.createRange(element, {count: position});
+            selection.getRangeAt(0).setStart(range.endContainer, range.endOffset);
+
+        }
+    }
+
     /**
      * Get the position of the end of the user selection
      * Based on https://stackoverflow.com/a/4812022/11247647

--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,7 @@
  * @author Alexandre Dewilde
  * @date 15/11/2020
  * @version 1.0.0
- * 
+ *
  */
 const fs = require('fs');
 const path = require('path');
@@ -15,7 +15,7 @@ const port = configs.PORT;
 const DEBUG = configs.DEBUG;
 const ssl = configs.SSL;
 const sslKeyPath = configs.KEY_FILE_SSL;
-const sslCertPath = configs.CERT_FILE_SSL; 
+const sslCertPath = configs.CERT_FILE_SSL;
 
 const options = ssl ? {
     key: fs.readFileSync(sslKeyPath.startsWith('/') ? sslKeyPath : path.join(__dirname, sslKeyPath), 'utf8'),
@@ -29,7 +29,7 @@ const http = ssl ? require('https') : require('http');
 const server = http.createServer(options, app);
 if (configs.METRICS) {
     const {metricsApp} = require('./metricsApp');
-    var metricsServer = http.createServer(metricsApp);
+    var metricsServer = require('http').createServer(metricsApp);
 }
 
 // config websockets

--- a/src/socket/socket.js
+++ b/src/socket/socket.js
@@ -66,7 +66,8 @@ module.exports = function (wss) {
 						broadcastRoomExceptSender(data, 'uuid', data.uuid);
 						const succesUpdatingDate = db.updateLastViewedDate(data.room);
 						const succesUpdate = db.applyRequests(data.room, data.data);
-						if (!succesUpdatingDate || !succesUpdate) socket.send(JSON.stringify({event: 'update', success: false}));
+						// /!\ Bad event
+						// if (!succesUpdatingDate || !succesUpdate) socket.send(JSON.stringify({event: 'update', success: false}));
 					} catch (err) {
 						if (config.DEBUG) {
 							console.error(err);
@@ -82,7 +83,7 @@ module.exports = function (wss) {
 						rooms[data.room][uuid] = socket;
 					}
 					break;
-				
+
 				case 'language':
 					try {
 						broadcastRoomExceptSender(data, 'language', data.language);


### PR DESCRIPTION
**Back-end**
- Remove websocket success = false when an error is raised in `update` event, because the event `update` was used in the answer.
- set HTTP protocol for metrics independently of ssl config.
- Default value for mongoDB `applyRequest` (Otherwise generates many console errors)

**Front-end**
- Cancel `keydown` event when user is out of a line and prevent it with alertCards.
- moves the caret one position when the first character of a line is deleted.